### PR TITLE
add-codecov: make coverage + integración con Codecov (umbral 80%)

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,18 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 80%
+        threshold: 1%
+    patch:
+      default:
+        target: 80%
+
+ignore:
+  - "test/**/*"
+  - "src/main.c"
+
+comment:
+  layout: "reach, diff, flags, files"
+  behavior: default
+  require_changes: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,26 +2,40 @@ name: C/C++ CI
 
 on:
   push:
-    branches: [ master, cSpec ]
+    branches: [ main ]
   pull_request:
-    branches: [ master, cSpec ]
+    branches: [ main ]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
-    - name: install dependencies
+    - uses: actions/checkout@v4
+
+    - name: Install lcov
+      run: sudo apt-get update && sudo apt-get install -y lcov
+
+    - name: Install cSpec
       run: |
-        git clone https://github.com/mumuki/cspec.git
-        cd cspec
+        git clone https://github.com/mumuki/cspec.git /tmp/cspec
+        cd /tmp/cspec
         make
-        make install
-    - name: make
-      run: make clean
-    - name: make all
-      run: make all
-    - name: run tests
-      run: ./eg-alumnos-c
+        sudo make install
+        sudo ldconfig
+
+    - name: Compilar demo
+      run: make
+
+    - name: Correr tests
+      run: make test
+
+    - name: Generar reporte de cobertura
+      run: make coverage
+
+    - name: Subir cobertura a Codecov
+      uses: codecov/codecov-action@v4
+      with:
+        files: build/lcov.info
+        fail_ci_if_error: true
+        token: ${{ secrets.CODECOV_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Ejercicio de modelado de Alumnos
 
 [![C/C++ CI](https://github.com/uqbar-project/eg-alumnos-c/actions/workflows/build.yml/badge.svg)](https://github.com/uqbar-project/eg-alumnos-c/actions/workflows/build.yml)
+[![codecov](https://codecov.io/gh/uqbar-project/eg-alumnos-c/branch/main/graph/badge.svg)](https://codecov.io/gh/uqbar-project/eg-alumnos-c)
 
 Resolución del ejercicio de alumno en ANSI C modelando con TADs y testeado con cSpec perteneciente [al apunte](https://docs.google.com/document/d/11C2UAbP70dP7sTID-ZxJm_a-5ypKxQUEuZr6GVk5yFI/edit?usp=sharing) de modelado del paradigma funcional.
 
@@ -180,8 +181,11 @@ Los tests no arrastran al `main.c`, y el demo no linkea cSpec. Cada binario hace
 make          # compila el demo
 make run      # compila y corre el demo
 make test     # compila y corre los tests
+make coverage # recompila con --coverage, corre tests, genera build/lcov.info
 make clean    # borra artefactos de build y binarios
 ```
+
+Para `make coverage` en local hace falta `lcov` instalado (`brew install lcov` en Mac, `apt install lcov` en Linux). El reporte que genera también se sube automáticamente a [Codecov](https://codecov.io/gh/uqbar-project/eg-alumnos-c) desde CI; el umbral mínimo del proyecto es 80%.
 
 ### Salida esperada del demo
 

--- a/makefile
+++ b/makefile
@@ -15,8 +15,12 @@ ifeq ($(UNAME), Darwin)
   ifeq ($(strip $(CC)),)
     $(error gcc de Homebrew no encontrado. Instalar con: brew install gcc)
   endif
+  # gcov debe ser el que matchea con la versión de gcc que usamos (el de
+  # Apple no entiende los .gcda/.gcno de gcc de Homebrew).
+  GCOV := $(subst gcc-,gcov-,$(CC))
 else
-  CC := gcc
+  CC   := gcc
+  GCOV := gcov
 endif
 
 # ───── Paths de CSpecs ─────
@@ -50,7 +54,7 @@ DEPS      := $(LIB_OBJS:.o=.d) $(MAIN_OBJ:.o=.d) $(TEST_OBJS:.o=.d)
 DEMO_BIN := eg-alumnos-c
 TEST_BIN := eg-alumnos-c-tests
 
-.PHONY: all run test clean
+.PHONY: all run test coverage clean
 
 # ───── Regla por defecto ─────
 all: $(DEMO_BIN)
@@ -81,6 +85,21 @@ run: $(DEMO_BIN)
 
 test: $(TEST_BIN)
 	./$(TEST_BIN)
+
+# ───── Cobertura ─────
+# `make coverage` recompila instrumentado con --coverage, corre los tests,
+# agrega los resultados en build/lcov.info y filtra paths irrelevantes
+# (sistema, cspec, tests propios, main del demo).
+coverage:
+	@$(MAKE) clean
+	@$(MAKE) $(TEST_BIN) CFLAGS='$(CFLAGS) --coverage' LDFLAGS='$(LDFLAGS) --coverage'
+	./$(TEST_BIN)
+	lcov --capture --directory $(OBJDIR) --output-file $(OBJDIR)/lcov.info \
+	     --gcov-tool $(GCOV) --ignore-errors inconsistent --quiet
+	lcov --remove $(OBJDIR)/lcov.info '/usr/*' '/opt/*' '*/test/*' '*/src/main.c' \
+	     --output-file $(OBJDIR)/lcov.info --ignore-errors unused,inconsistent --quiet
+	@echo ""
+	@lcov --summary $(OBJDIR)/lcov.info --ignore-errors inconsistent
 
 # ───── Dependencias automáticas ─────
 -include $(DEPS)


### PR DESCRIPTION
## Resumen

Suma medición de cobertura con lcov y la integra con Codecov desde CI. Umbral de proyecto y patch: 80%.

## Cambios

### makefile

- Nueva variable \`GCOV\` que deriva de \`CC\`: en Mac usa \`gcov-N\` matcheando la versión de gcc detectada (el gcov de Apple no lee los \`.gcda\` de gcc de Homebrew); en Linux queda \`gcov\` pelado.
- Nuevo target \`make coverage\`:
  - hace \`clean\`
  - recompila los tests con \`--coverage\` (vía sub-make con override de CFLAGS/LDFLAGS para no contaminar el build default)
  - corre los tests → se generan los \`.gcda\`
  - agrega con \`lcov --capture\` apuntando al \`GCOV\` correcto
  - filtra \`/usr/*\`, \`/opt/*\`, \`test/*\` y \`src/main.c\` para que el reporte cubra solo la librería (alumno/parcial/criterio)
  - imprime summary

### CI (\`.github/workflows/build.yml\`)

- Ramas actualizadas a \`main\` (antes disparaba en \`master\`/\`cSpec\`, que quedaron vacías después del merge de \`update-2026\`).
- \`checkout@v3\` → \`v4\`.
- Install de \`lcov\` vía apt.
- Steps separados: \`make\` (demo), \`make test\`, \`make coverage\`.
- Paso final: \`codecov-action@v4\` sube \`build/lcov.info\` usando \`CODECOV_TOKEN\` (ya configurado como secret del repo).

### \`.codecov.yml\` (nuevo)

- \`coverage.status.project.default.target: 80%\` (con threshold de 1% para no romper por fluctuaciones menores).
- \`coverage.status.patch.default.target: 80%\` (código nuevo en cada PR también debe cumplir).
- \`ignore\`: \`test/**\` y \`src/main.c\` — el reporte refleja solo la librería bajo test.

### README

- Badge de Codecov al lado del de CI.
- \`make coverage\` documentado en la tabla de targets con la dependencia de lcov (\`brew install lcov\` / \`apt install lcov\`).

## Cobertura actual (local)

\`\`\`
source files: 3
lines.......: 91.9% (34 of 37 lines)
functions...: 90.0% (9 of 10 functions)
\`\`\`

Por encima del umbral. La línea sin cubrir es \`setCriterioDeEstudio\`: los tests en \`main\` usan factory methods (\`crearAlumnoHijoDelRigor()\`, etc.) en lugar de construir un estudioso y cambiarle el criterio. Queda como oportunidad para sumar un test que ejercite el setter.

## Test plan

- [x] \`make coverage\` local genera \`build/lcov.info\` y reporta 91.9% líneas.
- [x] \`make\` (demo) y \`make test\` siguen funcionando sin flags de coverage.
- [x] \`CODECOV_TOKEN\` configurado como secret del repo.
- [ ] El workflow corre en este PR y sube el reporte a Codecov sin error.
- [ ] Codecov comenta en el PR con el diff de cobertura.